### PR TITLE
2_model task planning

### DIFF
--- a/1_format.yml
+++ b/1_format.yml
@@ -6,7 +6,7 @@ packages:
   - yaml
 
 sources:
-  - lib/src/psprintf.R
+  - lib/src/utils.R
   - 1_format/src/format_tasks.R
 
 targets:

--- a/1_format/src/format_tasks.R
+++ b/1_format/src/format_tasks.R
@@ -1,7 +1,3 @@
-get_site_ids <- function(file, comment = "#") {
-  read_csv(file, comment = comment)$site_id
-}
-
 lookup_meteo_file <- function(site_id) {
   #once the table exists, will lookup there
   sprintf("1_format/in/drivers/%s_meteo.feather.ind", site_id)

--- a/2_model.yml
+++ b/2_model.yml
@@ -6,6 +6,7 @@ packages:
 
 sources:
   - lib/src/utils.R
+  - lib/src/require_local.R
   - 2_model/src/models.R
   - 2_model/src/model_tasks.R
   - 2_model/src/evaluate.R

--- a/2_model.yml
+++ b/2_model.yml
@@ -6,33 +6,32 @@ packages:
   - keras
 
 sources:
+  - lib/src/utils.R
   - 2_model/src/models.R
+  - 2_model/src/model_tasks.R
   - 2_model/src/evaluate.R
 
 targets:
   2_model:
     depends:
-      - model_01
-      - model_01_eval
-      - model_02
-      - model_02_eval
-      - model_03
-      - model_03_eval
 
-  lake_name:
-    command: c(I('Mille Lacs'))
+  # read and subset the NN settings
+  settings:
+    command: yaml.load_file('lib/cfg/settings.yml')
+  model_cfg:
+    command: settings[I(c('model_functions'))]
 
-  model_01:
-    command: run_model_01(split_scaled_nn)
-  model_01_eval:
-    command: evaluate_model(model_01, split_scaled_nn, rmd_file="2_model/src/assessment.Rmd", lake_name = lake_name)
+  site_ids:
+    command: get_site_ids(file = 'lib/crosswalks/pipeline_3_lakes.csv')
 
-  model_02:
-    command: run_model_02(split_scaled_nn)
-  model_02_eval:
-    command: evaluate_model(model_02, split_scaled_nn, rmd_file="2_model/src/assessment.Rmd", lake_name = lake_name)
+  model_task_plan:
+    command: create_model_task_plan(site_ids, model_cfg, ind_dir = I("2_model"))
 
-  model_03:
-    command: run_model_03(split_scaled_nn)
-  model_03_eval:
-    command: evaluate_model(model_03, split_scaled_nn, rmd_file="2_model/src/assessment.Rmd", lake_name = lake_name)
+  2_model_tasks.yml:
+    command: create_model_task_makefile(task_plan = model_task_plan, makefile = target_name, ind_complete = TRUE)
+
+  #2_model/log/2_model_tasks.ind:
+  #  command: loop_tasks(task_plan = model_task_plan, task_makefile = '2_model_tasks.yml', num_tries = 1)
+
+
+

--- a/2_model.yml
+++ b/2_model.yml
@@ -1,15 +1,15 @@
 target_default: 2_model
 
 packages:
-  - dplyr
   - tidyr
-  - keras
+  - stringr
 
 sources:
   - lib/src/utils.R
   - 2_model/src/models.R
   - 2_model/src/model_tasks.R
   - 2_model/src/evaluate.R
+  - 2_model/src/fetch_formatted_data_tasks.R
 
 targets:
   2_model:
@@ -19,10 +19,19 @@ targets:
   settings:
     command: yaml.load_file('lib/cfg/settings.yml')
   model_cfg:
-    command: settings[I(c('model_functions'))]
+    command: settings[[I('model_functions')]]
 
   site_ids:
     command: get_site_ids(file = 'lib/crosswalks/pipeline_3_lakes.csv')
+
+  fetch_formatted_data_task_plan:
+    command: create_fetch_formatted_data_task_plan(site_ids, ind_dir = I("2_model"))
+
+  2_fetch_formatted_data_tasks.yml:
+    command: create_task_makefile(makefile=target_name, task_plan = fetch_formatted_data_task_plan, include = "2_model.yml")
+
+  2_model/log/2_fetch_formatted_data_tasks.ind:
+    command: loop_tasks(task_plan = fetch_formatted_data_task_plan, task_makefile = "2_fetch_formatted_data_tasks.yml", num_tries = 2)
 
   model_task_plan:
     command: create_model_task_plan(site_ids, model_cfg, ind_dir = I("2_model"))

--- a/2_model.yml
+++ b/2_model.yml
@@ -30,13 +30,13 @@ targets:
     command: create_fetch_formatted_data_task_plan(site_ids, ind_dir = I("2_model"))
 
   2_fetch_formatted_data_tasks.yml:
-    command: create_task_makefile(makefile=target_name, task_plan = fetch_formatted_data_task_plan, include = "2_model.yml")
+    command: create_task_makefile(makefile=target_name, task_plan = fetch_formatted_data_task_plan, include = I("2_model.yml"))
 
   2_model/log/2_fetch_formatted_data_tasks.ind:
     command: loop_tasks(task_plan = fetch_formatted_data_task_plan, task_makefile = "2_fetch_formatted_data_tasks.yml", num_tries = 2)
 
   model_task_plan:
-    command: create_model_task_plan(site_ids, model_cfg, ind_dir = I("2_model"))
+    command: create_model_task_plan(site_ids, model_cfg)
 
   2_model_tasks.yml:
     command: create_model_task_makefile(task_plan = model_task_plan, makefile = target_name, ind_complete = TRUE)

--- a/2_model.yml
+++ b/2_model.yml
@@ -14,6 +14,7 @@ sources:
 targets:
   2_model:
     depends:
+      - 2_model/log/2_model_tasks.ind
 
   # read and subset the NN settings
   settings:
@@ -39,8 +40,8 @@ targets:
   2_model_tasks.yml:
     command: create_model_task_makefile(task_plan = model_task_plan, makefile = target_name, ind_complete = TRUE)
 
-  #2_model/log/2_model_tasks.ind:
-  #  command: loop_tasks(task_plan = model_task_plan, task_makefile = '2_model_tasks.yml', num_tries = 1)
+  2_model/log/2_model_tasks.ind:
+    command: loop_tasks(task_plan = model_task_plan, task_makefile = '2_model_tasks.yml', num_tries = 1)
 
 
 

--- a/2_model.yml
+++ b/2_model.yml
@@ -3,6 +3,8 @@ target_default: 2_model
 packages:
   - tidyr
   - stringr
+  - dplyr
+  - zeallot
 
 sources:
   - lib/src/utils.R

--- a/2_model/src/evaluate.R
+++ b/2_model/src/evaluate.R
@@ -1,7 +1,10 @@
-evaluate_model <- function(model_list, dat, rmd_file, lake_name) {
+evaluate_model <- function(model_list_ind, dat_ind, rmd_file, site_id, output_html) {
+  model_list <- as_data_file(model_list_ind)
+  dat_ind <- as_data_file(dat_ind)
+  lake_name <- lookup_lake_name(site_id)
   rmarkdown::render(
     input = rmd_file,
     output_format = "html_document",
-    output_file = sprintf('model_%03d.html', model_list$id),
+    output_file = output_html,
     output_dir = "2_model/doc")
 }

--- a/2_model/src/evaluate.R
+++ b/2_model/src/evaluate.R
@@ -1,6 +1,6 @@
 evaluate_model <- function(model_list_ind, dat_ind, rmd_file, site_id, output_html) {
-  model_list <- as_data_file(model_list_ind)
-  dat_ind <- as_data_file(dat_ind)
+  model_list <- readRDS(as_data_file(model_list_ind))
+  dat <- readRDS(as_data_file(dat_ind))
   lake_name <- lookup_lake_name(site_id)
   rmarkdown::render(
     input = rmd_file,

--- a/2_model/src/fetch_formatted_data_tasks.R
+++ b/2_model/src/fetch_formatted_data_tasks.R
@@ -1,0 +1,24 @@
+create_fetch_formatted_data_task_plan <- function(site_ids, ind_dir) {
+  task <- list(create_task_step(
+    step_name = "split_scale_rds",
+    target_name = function(steps, task_name, ...) {
+      sprintf("1_format/out/%s_split_scaled.rds", task_name)
+    },
+    command = function(steps, task_name, ...) {
+      sprintf("gd_get('%s')", sprintf("1_format/out/%s_split_scaled.rds.ind", task_name))
+    }))
+  fetch_formatted_data_task_plan <- create_task_plan(
+    task_names = site_ids,
+    task_steps = task,
+    ind_dir = "2_model/log",
+    add_complete = FALSE)
+  return(fetch_formatted_data_task_plan)
+}
+
+create_model_task_makefile <- function(task_plan, makefile, ...) {
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = makefile,
+    include = "2_model.yml",
+    ...)
+}

--- a/2_model/src/model_tasks.R
+++ b/2_model/src/model_tasks.R
@@ -21,10 +21,7 @@ create_model_task_plan <- function(site_ids, model_function_names) {
                        as_data_file(steps[[1]]$target_name)
                      },
                      command = function(steps, ...) {
-                       steps[[1]]$target_name
-                     },
-                     depends = function(steps, ...) {
-                       steps[[1]]$target_name
+                       sprintf("require_local(\'%s\')", steps[[1]]$target_name)
                      }),
     create_task_step(step_name = "evaluate",
                      target_name = function(task_name, ...) {

--- a/2_model/src/model_tasks.R
+++ b/2_model/src/model_tasks.R
@@ -1,9 +1,69 @@
-# the model tasks plan will probably include this task_step:
-# create_task_step(
-#   step_name = "split_scale_rds",
-#   target_name = function(steps, ...) {
-#     sprintf("1_format/out/%s_split_scaled.rds", task_name)
-#   },
-#   command = function(steps, ...) {
-#     sprintf("gd_get('%s')", sprintf("1_format/out/%s_split_scaled.rds.ind", task_name))
-#   })
+create_model_and_eval_steps <- function(model_functions) {
+  model_steps <- NULL
+  for(func in model_functions) {
+    print(func)
+    run_step <- create_task_step(step_name = paste0(func, "_ind"),
+                                 target_name = function(steps, task_name, ...) {
+                                   sprintf("2_model/out/%s_%s_model_out.rds.ind", steps[[1]]$step_name, task_name)
+                                 },
+                                 command = function(steps, ...) {
+                                   sprintf("%s(%s)", func, steps[['split_scale_rds']]$target_name)
+                                 })
+    run_get_local_step <- create_task_step(step_name = paste0(func, "_rds"),
+                                           target_name = function(steps, task_name, func = func, ...) {
+                                             sprintf("2_model/out/%s_%s_model_out.rds", func, task_name)
+                                           },
+                                           command = function(steps, ...) {
+                                             #print(lapply(steps, `[`, "step_name"))
+                                             run_ind_step <- paste0(func, "_ind")
+                                             #print(steps[[run_ind_step]]$target_name)
+                                             #print(run_ind_step)
+                                             sprintf("gd_get(%s)", steps[[run_ind_step]]$target_name)
+                                           })
+    # eval_step <- create_task_step(step_name = paste0("evaluate_", func),
+    #                               target_name = function(task_name, ...) {
+    #                                 sprintf("2_model/doc/%s_")
+    #                               })
+    if(!is.null(model_steps)) {
+      model_steps <- c(model_steps, list(run_step, run_get_local_step))
+    } else {
+      model_steps <- list(run_step, run_get_local_step)
+    }
+
+  }
+  return(model_steps)
+}
+
+
+create_model_task_plan <- function(site_ids, settings, ind_dir) {
+  task_steps <- c(
+    list(create_task_step(
+      step_name = "split_scale_rds",
+      target_name = function(steps, task_name, ...) {
+        sprintf("1_format/out/%s_split_scaled.rds", task_name)
+      },
+      command = function(steps, task_name, ...) {
+        sprintf("gd_get('%s')", sprintf("1_format/out/%s_split_scaled.rds.ind", task_name))
+      })),
+    create_model_and_eval_steps(settings[['model_functions']])
+  )
+  saveRDS(task_steps, 'task_steps.rds')
+  model_task_plan <- create_task_plan(
+    task_names = site_ids,
+    task_steps = task_steps,
+    #final_steps = "",
+    ind_dir = "2_model/log",
+    add_complete = FALSE)
+
+  return(model_task_plan)
+}
+
+create_model_task_makefile <- function(task_plan, makefile, ...) {
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = makefile,
+    packages = c("dplyr", "tidyr", "keras"),
+    sources = c("lib/src/require_local.R", "2_model/src/models.R"),
+    include = "2_model.yml",
+    ...)
+}

--- a/2_model/src/model_tasks.R
+++ b/2_model/src/model_tasks.R
@@ -5,7 +5,7 @@ get_model_func_site_id <- function(task_name) {
   return(list(site_id, model_func))
 }
 
-create_model_task_plan <- function(site_ids, model_function_names, ind_dir) {
+create_model_task_plan <- function(site_ids, model_function_names) {
   model_function_names <- as.character(model_function_names)
   task_steps <- list(
     create_task_step(step_name = "model_output_ind",
@@ -20,7 +20,9 @@ create_model_task_plan <- function(site_ids, model_function_names, ind_dir) {
                      target_name = function(steps, ...) {
                        as_data_file(steps[[1]]$target_name)
                      },
-                     command = "require_local_as_ind(target_name)",
+                     command = function(steps, ...) {
+                       steps[[1]]$target_name
+                     },
                      depends = function(steps, ...) {
                        steps[[1]]$target_name
                      }),

--- a/2_model/src/model_tasks.R
+++ b/2_model/src/model_tasks.R
@@ -20,7 +20,7 @@ create_model_task_plan <- function(site_ids, model_function_names, ind_dir) {
                      target_name = function(steps, ...) {
                        as_data_file(steps[[1]]$target_name)
                      },
-                     command = "require_local(target_name)",
+                     command = "require_local_as_ind(target_name)",
                      depends = function(steps, ...) {
                        steps[[1]]$target_name
                      }),
@@ -32,7 +32,7 @@ create_model_task_plan <- function(site_ids, model_function_names, ind_dir) {
                        c(site_id, model_func) %<-% get_model_func_site_id(task_name)
                        model_output <- steps[[1]]$target_name
                        formatted_data <- sprintf("1_format/out/%s_split_scaled.rds.ind", site_id)
-                       sprintf("evaluate_model(model_list_ind = I(\'%s\'), dat_ind = I(\'%s\'), rmd_file='2_model/src/assessment.Rmd', site_id = \'%s\', output_html = target_name)",
+                       sprintf("evaluate_model(output_html = target_name, model_list_ind = \'%s\', dat_ind = \'%s\', rmd_file='2_model/src/assessment.Rmd', site_id = I(\'%s\'))",
                                model_output, formatted_data, site_id)
                        },
                      depends = function(steps, ...) {
@@ -56,8 +56,8 @@ create_model_task_makefile <- function(task_plan, makefile, ...) {
   create_task_makefile(
     task_plan = task_plan,
     makefile = makefile,
-    packages = c("dplyr", "tidyr", "keras"),
-    sources = c("lib/src/require_local.R", "2_model/src/models.R"),
+    packages = c("dplyr", "tidyr", "keras", "scipiper"),
+    source = c("lib/src/require_local.R", "2_model/src/models.R", "lib/src/utils.R", "lib/src/require_local.R"),
     include = "2_model.yml",
     ...)
 }

--- a/2_model/src/models.R
+++ b/2_model/src/models.R
@@ -1,5 +1,6 @@
 run_model_01 <- function(data_ind, out_ind) {
-  dat <- as_data_file(data_ind)
+  dat <- readRDS(as_data_file(data_ind))
+
   # configure
   l2_lambda <- 0.5 #regularization factors, L1 and L2 regularization
   l1_lambda <- 0.5
@@ -37,7 +38,7 @@ run_model_01 <- function(data_ind, out_ind) {
 }
 
 run_model_02 <- function(data_ind, out_ind) {
-  dat <- as_data_file(data_ind)
+  dat <- readRDS(as_data_file(data_ind))
   # configure
   reg <- regularizer_l2(0.5)
   init <- initializer_random_uniform(0,1)
@@ -86,7 +87,7 @@ run_model_02 <- function(data_ind, out_ind) {
 }
 
 run_model_03 <- function(data_ind, out_ind) {
-  dat <- as_data_file(data_ind)
+  dat <- readRDS(as_data_file(data_ind))
   # configure
   reg <- regularizer_l2(0.5)
   init <- initializer_random_uniform(0,1)

--- a/2_model/src/models.R
+++ b/2_model/src/models.R
@@ -1,5 +1,5 @@
-run_model_01 <- function(dat) {
-
+run_model_01 <- function(data_ind, out_ind) {
+  dat <- as_data_file(data_ind)
   # configure
   l2_lambda <- 0.5 #regularization factors, L1 and L2 regularization
   l1_lambda <- 0.5
@@ -30,11 +30,14 @@ run_model_01 <- function(dat) {
     validation_split = 0.1)
 
   # package and return the results
-  return(list(id=1, description="as in Anuj's paper", serialized=serialize_model(network), history=history))
+  out <- list(id=1, description="as in Anuj's paper", serialized=serialize_model(network), history=history)
+  out_data_file <- as_data_file(out_ind)
+  saveRDS(out, file = out_data_file)
+  sc_indicate(out_ind, data_file = out_data_file)
 }
 
-run_model_02 <- function(dat) {
-
+run_model_02 <- function(data_ind, out_ind) {
+  dat <- as_data_file(data_ind)
   # configure
   reg <- regularizer_l2(0.5)
   init <- initializer_random_uniform(0,1)
@@ -76,11 +79,14 @@ run_model_02 <- function(dat) {
         validation_split = 0.1)
 
   # package and return the results
-  return(list(id=2, description="Anuj's paper but L2 reg, Adam optimization, batch_size=1024", serialized=serialize_model(network), history=history))
+  out <- list(id=2, description="Anuj's paper but L2 reg, Adam optimization, batch_size=1024", serialized=serialize_model(network), history=history)
+  out_data_file <- as_data_file(out_ind)
+  saveRDS(out, file = out_data_file)
+  sc_indicate(out_ind, data_file = out_data_file)
 }
 
-run_model_03 <- function(dat) {
-
+run_model_03 <- function(data_ind, out_ind) {
+  dat <- as_data_file(data_ind)
   # configure
   reg <- regularizer_l2(0.5)
   init <- initializer_random_uniform(0,1)
@@ -121,5 +127,8 @@ run_model_03 <- function(dat) {
         validation_split = 0.1)
 
   # package and return the results
-  return(list(id=3, description="Anuj's paper but L2 reg, Adam optimization, batch_size=1024, 30% dropout", serialized=serialize_model(network), history=history))
+  out <- list(id=3, description="Anuj's paper but L2 reg, Adam optimization, batch_size=1024, 30% dropout", serialized=serialize_model(network), history=history)
+  out_data_file <- as_data_file(out_ind)
+  saveRDS(out, file = out_data_file)
+  sc_indicate(out_ind, data_file = out_data_file)
 }

--- a/lib/cfg/settings.yml
+++ b/lib/cfg/settings.yml
@@ -8,3 +8,8 @@ structure: 'NN'
 # split_scale_nn_data
 dev_frac: 0.20
 test_frac: 0.20
+
+# 2_model
+model_functions:
+  - run_model_01
+  - run_model_02

--- a/lib/src/require_local.R
+++ b/lib/src/require_local.R
@@ -23,3 +23,7 @@ require_local <- function(ind_file) {
 
   invisible()
 }
+
+require_local_as_ind <- function(dat_file) {
+  require_local(as_ind_file(dat_file))
+}

--- a/lib/src/utils.R
+++ b/lib/src/utils.R
@@ -12,3 +12,11 @@ psprintf <- function(..., sep='\n      ') {
 get_site_ids <- function(file, comment = "#") {
   read_csv(file, comment = comment)$site_id
 }
+
+lookup_lake_name <- function(site_id) {
+  #switch to full lake name crosswalk in the future
+  lake_name <- read_csv("lib/crosswalks/pipeline_3_lakes.csv") %>% filter(site_id == site_id) %>%
+    .$name %>% unique()
+  assertthat::assert_that(length(lake_name == 1))
+  return(lake_name)
+}

--- a/lib/src/utils.R
+++ b/lib/src/utils.R
@@ -8,3 +8,7 @@ psprintf <- function(..., sep='\n      ') {
   }, string=names(args), variables=args)
   paste(strs, collapse=sep)
 }
+
+get_site_ids <- function(file, comment = "#") {
+  read_csv(file, comment = comment)$site_id
+}

--- a/lib/src/utils.R
+++ b/lib/src/utils.R
@@ -13,10 +13,10 @@ get_site_ids <- function(file, comment = "#") {
   read_csv(file, comment = comment)$site_id
 }
 
-lookup_lake_name <- function(site_id) {
+lookup_lake_name <- function(lake_site_id) {
   #switch to full lake name crosswalk in the future
-  lake_name <- read_csv("lib/crosswalks/pipeline_3_lakes.csv") %>% filter(site_id == site_id) %>%
+  lake_name <- read_csv("lib/crosswalks/pipeline_3_lakes.csv", comment = "#") %>% filter(site_id == lake_site_id) %>%
     .$name %>% unique()
-  assertthat::assert_that(length(lake_name == 1))
+  assertthat::assert_that(length(lake_name) == 1)
   return(lake_name)
 }


### PR DESCRIPTION
This PR adds task planning for the `2_model` step.  There are two task remake files --- one pulls down the formatted input data for each `site_id`, the second runs each model function specified in `settings.yml` for every `site_id`, then creates the summary html file.  

The dependency tree from `remake::diagram(remake_file = '2_model_tasks.yml`):
![image](https://user-images.githubusercontent.com/13987349/45841993-0a397000-bce1-11e8-9a6c-86088813f102.png)

Note that some of the changes here might break `2_explore_models.yml` due to things like handling .ind files instead of data files.  These could probably be worked around.
