### PR TITLE
code for tuning on slurm, modified from xiaowei's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ build/status/MV9mb3JtYXQvdG1wL25oZF*
 *tasks.yml
 *.feather
 in/driver-data/*.csv
+tf_tuning/*.npy
+tf_tuning/mille/data/*.npy
+tf_tuning/mille/out/pretrain*
+tf_tuning/mille/out/train*

--- a/tf_tuning/README.txt
+++ b/tf_tuning/README.txt
@@ -1,0 +1,10 @@
+This directory has a file called model_params.py. That file should be run with python to create model_params.npy.
+
+The mille/data directory should be populated locally with the Mille Lacs data, which are available at https://drive.google.com/drive/u/0/folders/1ZS8J68fakGfmJQiPJLY9D_yVUegGTPfc.
+
+Then you can run a model.
+* One entrypoint is apply_pgnn.py, which defines a function that will build and train a PGRNN on the specified dataset. This script in turn uses prep_data.py, tf_graph.py, tf_train.py, and (through tf_graph.py) physics.py to get its work done.
+* A higher-level entrypoint is run_job.py, which will accept a command-line argument for the job ID to run, will look up that job's specifications in model_params.npy, and will run apply_pgnn() for those specifications.
+* The highest-level entrypoint is slurm_jobs.sh, which defines a Slurm batch for running multiple run_job.py jobs.
+
+The output will appear in mille/out, with one subfolder per model application (job).

--- a/tf_tuning/apply_pgnn.py
+++ b/tf_tuning/apply_pgnn.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec 12 18:06:57 2018
+
+@author: aappling
+"""
+
+from __future__ import print_function, division
+import random
+import prep_data
+import tf_graph
+import tf_train
+
+def apply_pgnn(
+        input_size = 9,
+        phy_size = 10,
+        n_steps = 50,
+        batch_size = 500,
+        learning_rate = 0.005,
+        state_size = 8,
+        ec_threshold = 24,
+        plam = 0.15,
+        elam = 0.00025,
+        
+        x_full_file = 'processed_features.npy',
+        x_raw_full_file = 'features.npy',
+        diag_full_file = 'diag.npy',
+        depth_areas_file = 'depth_areas.npy',
+        label_file = 'Obs_temp_mille.npy',
+        mask_file = 'Obs_mask_mille.npy',
+        train_range = range(10000, 12500), # for Mille Lacs we're using the later part of the data for training, previous years for testing
+        test_range = range(10000),
+        data_path = 'data',
+        
+        tot_epochs = 300,
+        min_epochs_test = 0,
+        min_epochs_save = 250,
+        restore_path = './out/EC_mille/pretrain',
+        save_path = './out/EC_mille',
+        max_to_keep = 3,
+        save_preds = True
+    ):
+    """Train (or pretrain) a PGRNN, optionally save the weights+biases and/or predictions, and return the predictions
+    
+    Args:
+        input_size: # Number of features in input. Must match between pretrain and train
+        phy_size: Number of features in physics data (unnormalized input). Must match between pretrain and train
+        n_steps: Number of timesteps within a window. should be even number and divide evenly into batch_size. Must match between pretrain and train
+        batch_size: Number of dates (timesteps) within one batch. We're not breaking epochs into batches, but we do prep data in the shape of batches stacked vertically, such that we could use training batches later if desired. Should divide evenly into training and test range lengths.
+        learning_rate: NN learning rate
+        state_size: Number of units in each cell's hidden state
+        ec_threshold: Energy imbalance beyond which NN will be penalized
+        plam: PRESENTLY IGNORED. physics (depth-density) constraint lambda, multiplier to physics loss when adding to other losses
+        elam: energy constraint lambda, multiplier to energy balance loss when adding to other losses
+        
+        x_full_file: Filename of normalized inputs (climate, possibly GLM)
+        x_raw_full_file: Filename of raw (unnormalized) inputs
+        diag_full_file: Filename of supplemental inputs for unsupervised training
+        depth_areas_file: Filename of np array of depth areas. The length of this array is used to determine number of depths
+        label_file: Filename of labels (temperature observations for training; GLM predictions for pretraining)
+        mask_file: Filename of label masks (0 where temp obs/GLM pred unavailable, 1 where available)
+        train_range: Date/timestep range or indices to select from the input files for training. Use a smaller range (2500) unless you have large-memory (~32Gb) GPU in which case 7500 is OK.
+        test_range: Date/timestep range or indices to select from the input files for testing. 
+        data_path: Path to the data files. './data' is recommended.
+        
+        tot_epochs: Total number of epochs to run during training. Needs to be larger than the n epochs needed for the model to converge
+        min_epochs_test: Minimum number of epochs to run through before computing test losses
+        min_epochs_save: Minimum number of epochs to run through before considering saving a checkpoint (must be >= min_epochs_test)
+        restore_path: Path to restore a model from, or ''
+        save_path: Path (directory) to save a model to. Will always be saved as ('checkpoint_%s' %>% epoch)
+        max_to_keep: Max number of checkpoints to keep in the save_path
+        save_preds: Logical - should test predictions be saved (and ovewritten) each time we save a checkpoint?
+    """
+    
+    print('printing status')
+    print('restore_path: %s' % restore_path)
+    print('save_path: %s' % save_path)
+    
+    random.seed(9001)
+    
+    # %% Compute constants
+    
+    # Compute info shared across multiple cells below
+    N_sec = (int(batch_size/n_steps)-1)*2+1 # number of 50% overlapping sections (windows) per batch
+    
+    # %% Load and prepare data
+    x_train_1, y_train_1, m_train_1, x_f, p_f, x_test, y_test, m_test, depth_areas = prep_data.prep_data(
+            N_sec, n_steps, batch_size, input_size, phy_size,
+            x_full_file = x_full_file,
+            x_raw_full_file = x_raw_full_file,
+            diag_full_file = diag_full_file,
+            depth_areas_file = depth_areas_file,
+            label_file = label_file,
+            mask_file = mask_file,
+            train_range = train_range,
+            test_range = test_range,
+            data_path = data_path)
+    
+    # %% Build graph
+    train_op, cost, r_cost, pred, unsup_loss, x, y, m, unsup_inputs, unsup_phys_data = tf_graph.build_tf_graph(
+            n_steps, input_size, state_size, phy_size, depth_areas,
+            ec_threshold, plam, elam, N_sec, learning_rate)
+    
+    # %% Train model
+    prd = tf_train.train_tf_graph(
+            train_op, cost, r_cost, pred, unsup_loss, x, y, m, unsup_inputs, unsup_phys_data,
+            x_train_1, y_train_1, m_train_1, x_f, p_f, x_test, y_test, m_test,
+            tot_epochs=tot_epochs, min_epochs_test=min_epochs_test, min_epochs_save=min_epochs_save,
+            restore_path=restore_path, save_path=save_path, max_to_keep=max_to_keep, save_preds=save_preds)
+    
+    return(prd)
+    # %% Inspect predictions
+    
+    # prd has dimensions [depths*batches, n timesteps per batch, 1]
+    # xiaowei has a separate script that combines batches into a single time series. he uses the first occurence of each prediction as the final value because it's better (has more preceding info to build on)
+    
+    # visualize prd_EC, see Create_sparse_data.py
+    #prd = np.load('prd_EC_mille.npy')

--- a/tf_tuning/mille/data/README.txt
+++ b/tf_tuning/mille/data/README.txt
@@ -1,0 +1,10 @@
+The contents of this data directory should be:
+depth_areas.npy
+diag.npy
+features.npy
+labels.npy
+Obs_mask_mille.npy
+Obs_temp_mille.npy
+processed_features.npy
+
+While not on GitHub, those files are shared with our team at https://drive.google.com/drive/u/0/folders/1ZS8J68fakGfmJQiPJLY9D_yVUegGTPfc.

--- a/tf_tuning/mille/out/README.txt
+++ b/tf_tuning/mille/out/README.txt
@@ -1,0 +1,26 @@
+This directory will be populated when you run run_job.py (possibly by running slurm_jobs.sh). Each new model application corresponding to an element of the dictionary defined by model_params.py will get its own folder within this directory; that folder will have a name that matches the dictionary element. For example, after running the first and fourth jobs indicated by model_params.py, you might see:
+
+mille
+  out
+    pretrain_1a
+      checkpoint
+      checkpoint_297.data-00000-of-00001
+      checkpoint_297.index
+      checkpoint_297.meta
+      checkpoint_298.data-00000-of-00001
+      checkpoint_298.index
+      checkpoint_298.meta
+      checkpoint_299.data-00000-of-00001
+      checkpoint_299.index
+      checkpoint_299.meta
+    train_1a
+      checkpoint
+      checkpoint_255.data-00000-of-00001
+      checkpoint_255.index
+      checkpoint_255.meta
+      checkpoint_256.data-00000-of-00001
+      checkpoint_256.index
+      checkpoint_256.meta
+      checkpoint_257.data-00000-of-00001
+      checkpoint_257.index
+      checkpoint_257.meta

--- a/tf_tuning/model_params.py
+++ b/tf_tuning/model_params.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec 12 17:55:26 2018
+
+@author: aappling
+"""
+
+import numpy as np
+
+model_params = dict(
+    pretrain_1a = dict(
+        state_size = 5
+    ),
+    pretrain_1b = dict(
+        state_size = 9
+    ),
+    pretrain_1c = dict(
+        state_size = 18
+    ),
+    train_1a = dict(
+        state_size = 5 # n*0.5
+    ),
+    train_1b = dict(
+        state_size = 9 # equal to input size n
+    ),
+    train_1c = dict(
+        state_size = 18 # n*2
+    )
+)
+
+np.save('model_params.npy', model_params)

--- a/tf_tuning/physics.py
+++ b/tf_tuning/physics.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Dec  6 09:19:10 2018
+
+@author: aappling
+"""
+
+import numpy as np
+import tensorflow as tf
+
+def transformTempToDensity(temp):
+    # print(temp)
+    #converts temperature to density
+    #parameter:
+        #@temp: single value or array of temperatures to be transformed
+    densities = 1000*(1-((temp+288.9414)*tf.pow(temp- 3.9863,2))/(508929.2*(temp+68.12963)))
+    # densities[:] = 1000*(1-((temp[:]+288.9414)*torch.pow(temp[:] - 3.9863))/(508929.2*(temp[:]+68.12963)))
+
+    return densities
+
+#def calculate_density_loss(prd, npic, n_steps):
+#                # calculate phy-loss
+#                ploss = 0
+#                prd_d = 1000*(1-(prd+288.9414)*((prd-3.9863)**2)/(508929.2*(prd+68.12963))) # density
+#                for k in range(51*npic-1):
+#                    if (k+1)%51!=0:
+#                        dif = np.reshape((prd_d[k,:,:]-prd_d[k+1,:,:]>0),[1,n_steps])
+#                        dif = np.maximum(np.zeros([1,n_steps]),dif)
+#                        ploss = ploss+np.sum(dif)
+#                ploss = ploss/n_steps/npic/50
+#                return ploss
+
+def calculate_ec_loss(inputs, outputs, phys, depth_areas, n_depths, ec_threshold, n_sets, combine_days=1):
+    #******************************************************
+    #description: calculates energy conservation loss
+    #parameters: 
+        #@inputs: features
+        #@outputs: labels
+        #@phys: features(not standardized) of sw_radiation, lw_radiation, etc
+        #@labels modeled temp (will not used in loss, only for test)
+        #@depth_areas: cross-sectional area of each depth
+        #@n_depths: number of depths
+        #@use_gpu: gpu flag
+        #@n_sets: number of sets of depths in the batch
+        #@combine_days: how many days to look back to see if energy is conserved
+    #*********************************************************************************
+    
+#    diff_vec = torch.empty((inputs.size()[1]))
+#    n_dates = inputs.size()[1]
+    # outputs = labels
+    
+#    outputs = outputs.view(outputs.size()[0], outputs.size()[1])
+    # print("modeled temps: ", outputs)
+    densities = transformTempToDensity(outputs)
+    # print("modeled densities: ", densities)
+
+    diff_per_set = [] #torch.empty(n_sets) 
+    for i in range(n_sets):
+        #loop through sets of n_depths
+        #indices
+        start_index = (i)*n_depths
+        end_index = (i+1)*n_depths
+
+        #calculate lake energy for each timestep
+        lake_energies = calculate_lake_energy(outputs[start_index:end_index,:], densities[start_index:end_index,:], depth_areas)
+        #calculate energy change in each timestep
+        lake_energy_deltas = calculate_lake_energy_deltas(lake_energies, combine_days, depth_areas[0])
+        lake_energy_deltas = lake_energy_deltas[1:]
+        #calculate sum of energy flux into or out of the lake at each timestep
+        # print("dates ", dates[0,1:6])
+        lake_energy_fluxes = calculate_energy_fluxes(phys[start_index,:,:], outputs[start_index,:], combine_days)
+#        ### can use this to plot energy delta and flux over time to see if they line up
+#        doy = np.array([datetime.datetime.combine(date.fromordinal(x), datetime.time.min).timetuple().tm_yday  for x in dates[start_index,:]])
+#        doy = doy[1:-1]
+        
+#        print(lake_energy_deltas)
+        diff_vec = tf.abs(lake_energy_deltas - lake_energy_fluxes) #.abs_()
+        
+        # mendota og ice guesstimate
+        # diff_vec = diff_vec[np.where((doy[:] > 134) & (doy[:] < 342))[0]]
+
+        #actual ice
+#        print(diff_vec)
+#        print(phys)
+        tmp_mask = 1-phys[start_index+1,1:-1,9] #(phys[start_index+1,:,9] == 0) # don't apply EC to the ice-on period. the mask is a column in the phys matrix (it's a boolean)
+#        print(tmp_mask)
+#        print(diff_vec)
+#        print(tmp_mask)
+        tmp_loss = tf.reduce_mean(diff_vec*tf.cast(tmp_mask,tf.float32))
+        diff_per_set.append(tmp_loss)
+        
+##        print(phys)
+#        diff_vec = diff_vec[tf.where((phys[1:(n_depths-tf.shape(diff_vec)[0]-1),9] == 0))[0]]
+#        # #compute difference to be used as penalty
+#        if tf.shape(diff_vec)[0]==0: #.size() == torch.Size([0]):
+#            diff_per_set.append(0) #diff_per_set[i] = 0
+#        else:
+#            diff_per_set.append(tf.reduce_mean(diff_vec)) #diff_per_set[i] = diff_vec.mean()
+
+    diff_per_set_r = tf.stack(diff_per_set)
+    
+    diff_per_set = tf.clip_by_value(diff_per_set_r - ec_threshold, clip_value_min=0,clip_value_max=999999)
+#    diff_per_set = torch.clamp(diff_per_set - ec_threshold, min=0)
+    return tf.reduce_mean(diff_per_set),diff_vec,diff_per_set_r,diff_per_set #, lake_energy_deltas, lake_energy_fluxes#.mean()
+
+def calculate_lake_energy(temps, densities, depth_areas):
+    #calculate the total energy of the lake for every timestep
+    #sum over all layers the (depth cross-sectional area)*temp*density*layer_height)
+    #then multiply by the specific heat of water 
+    dz = 0.5 #thickness for each layer, hardcoded for now
+    cw = 4186 #specific heat of water
+#    energy = torch.empty_like(temps[0,:])
+    n_depths = 24
+#    depth_areas = depth_areas.view(n_depths,1).expand(n_depths, temps.size()[1])
+
+#    print(depth_areas)
+    depth_areas = tf.reshape(depth_areas,[n_depths,1])
+    energy = tf.reduce_sum(tf.multiply(tf.cast(depth_areas,tf.float32),temps)*densities*dz*cw,0)
+    return energy
+
+
+def calculate_lake_energy_deltas(energies, combine_days, surface_area):
+    #given a time series of energies, compute and return the differences
+    # between each time step, or time step interval (parameter @combine_days)
+    # as specified by parameter @combine_days
+#    energy_deltas = torch.empty_like(energies[0:-combine_days])
+    time = 86400 #seconds per day
+    # surface_area = 39865825
+    energy_deltas = (energies[1:] - energies[:-1])/time/surface_area
+#    energy_deltas = (energies[1:] - energies[:-1])/(time*surface_area)
+    # for t in range(1, energy_deltas.size()[0]):
+    #     energy_deltas[t-1] = (energies[t+combine_days] - energies[t])/(time*surface_area) #energy difference converted to W/m^2
+    return energy_deltas
+
+
+def calculate_air_density(air_temp, rh):
+    #returns air density in kg / m^3
+    #equation from page 13 GLM/GLEON paper(et al Hipsey)
+
+    #Ratio of the molecular (or molar) weight of water to dry air
+    mwrw2a = 18.016 / 28.966
+    c_gas = 1.0e3 * 8.31436 / 28.966
+
+    #atmospheric pressure
+    p = 1013. #mb
+
+    #water vapor pressure
+    vapPressure = calculate_vapour_pressure_air(rh,air_temp)
+
+    #water vapor mixing ratio (from GLM code glm_surface.c)
+    r = mwrw2a * vapPressure/(p - vapPressure)
+    # print( 0.348*(1+r)/(1+1.61*r)*(p/(air_temp+273.15)))
+    # print("vs")
+    # print(1.0/c_gas * (1 + r)/(1 + r/mwrw2a) * p/(air_temp + 273.15))
+    # sys.exit()
+    # return 0.348*(1+r)/(1+1.61*r)*(p/(air_temp+273.15))
+    return (1.0/c_gas * (1 + r)/(1 + r/mwrw2a) * p/(air_temp + 273.15))*100# 
+def calculate_heat_flux_sensible(surf_temp, air_temp, rel_hum, wind_speed):
+    #equation 22 in GLM/GLEON paper(et al Hipsey)
+    #GLM code ->  Q_sensibleheat = -CH * (rho_air * 1005.) * WindSp * (Lake[surfLayer].Temp - MetData.AirTemp);
+    #calculate air density 
+    rho_a = calculate_air_density(air_temp, rel_hum)
+
+    #specific heat capacity of air in J/(kg*C)
+    c_a = 1005.
+
+
+    #bulk aerodynamic coefficient for sensible heat transfer
+    c_H = 0.0013
+
+    #wind speed at 10m
+    U_10 = calculate_wind_speed_10m(wind_speed)
+    # U_10 = wind_speed
+    return -rho_a*c_a*c_H*U_10*(surf_temp - air_temp)
+ 
+def calculate_heat_flux_latent(surf_temp, air_temp, rel_hum, wind_speed):
+    #equation 23 in GLM/GLEON paper(et al Hipsey)
+    #GLM code-> Q_latentheat = -CE * rho_air * Latent_Heat_Evap * (0.622/p_atm) * WindSp * (SatVap_surface - MetData.SatVapDef)
+    # where,         SatVap_surface = saturated_vapour(Lake[surfLayer].Temp);
+    #                rho_air = atm_density(p_atm*100.0,MetData.SatVapDef,MetData.AirTemp);
+    #air density in kg/m^3
+    rho_a = calculate_air_density(air_temp, rel_hum)
+
+    #bulk aerodynamic coefficient for latent heat transfer
+    c_E = 0.0013
+
+    #latent heat of vaporization (J/kg)
+    lambda_v = 2.453e6
+
+    #wind speed at 10m height
+    # U_10 = wind_speed
+    U_10 = calculate_wind_speed_10m(wind_speed)
+# 
+    #ratio of molecular weight of water to that of dry air
+    omega = 0.622
+
+    #air pressure in mb
+    p = 1013.
+
+    e_s = calculate_vapour_pressure_saturated(surf_temp)
+    e_a = calculate_vapour_pressure_air(rel_hum, air_temp)
+    return -rho_a*c_E*lambda_v*U_10*(omega/p)*(e_s - e_a)
+
+
+def calculate_vapour_pressure_air(rel_hum, temp):
+    rh_scaling_factor = 1
+    return rh_scaling_factor * (rel_hum / 100) * calculate_vapour_pressure_saturated(temp)
+
+def calculate_vapour_pressure_saturated(temp):
+    # returns in miilibars
+    # print(torch.pow(10, (9.28603523 - (2332.37885/(temp+273.15)))))
+
+    #Converted pow function to exp function workaround pytorch not having autograd implemented for pow
+    exponent = (9.28603523 - (2332.37885/(temp+273.15))*np.log(10))
+    return tf.exp(exponent)
+
+def calculate_wind_speed_10m(ws, ref_height=2.):
+    #from GLM code glm_surface.c
+    c_z0 = 0.001 #default roughness
+    return ws*(tf.log(10.0/c_z0)/tf.log(ref_height/c_z0))
+
+
+def calculate_energy_fluxes(phys, surf_temps, combine_days):
+    # print("surface_depth = ", phys[0:5,1])
+#    fluxes = torch.empty_like(phys[:-combine_days-1,0])
+
+    # E = phys_operations.calculate_heat_flux_latent(t_s, air_temp, rel_hum, ws)
+    # H = phys_operations.calculate_heat_flux_sensible(t_s, air_temp, rel_hum, ws)
+#    time = 86400 #seconds per day
+#    surface_area = 39865825 
+    e_s = 0.985 #emissivity of water, given by Jordan
+    alpha_sw = 0.07 #shortwave albedo, given by Jordan Read
+    alpha_lw = 0.03 #longwave, albeda, given by Jordan Read
+    sigma = 5.67e-8 #Stefan-Baltzmann constant
+    R_sw_arr = phys[:-1,2] + (phys[1:,2]-phys[:-1,2])/2
+    R_lw_arr = phys[:-1,3] + (phys[1:,3]-phys[:-1,3])/2
+    R_lw_out_arr = e_s*sigma*(tf.pow(surf_temps[:]+273.15, 4))
+    R_lw_out_arr = R_lw_out_arr[:-1] + (R_lw_out_arr[1:]-R_lw_out_arr[:-1])/2
+
+    air_temp = phys[:-1,4] 
+    air_temp2 = phys[1:,4]
+    rel_hum = phys[:-1,5]
+    rel_hum2 = phys[1:,5]
+    ws = phys[:-1, 6]
+    ws2 = phys[1:,6]
+    t_s = surf_temps[:-1]
+    t_s2 = surf_temps[1:]
+    E = calculate_heat_flux_latent(t_s, air_temp, rel_hum, ws)
+    H = calculate_heat_flux_sensible(t_s, air_temp, rel_hum, ws)
+    E2 = calculate_heat_flux_latent(t_s2, air_temp2, rel_hum2, ws2)
+    H2 = calculate_heat_flux_sensible(t_s2, air_temp2, rel_hum2, ws2)
+    E = (E + E2)/2
+    H = (H + H2)/2
+
+#    #test
+#    print(R_sw_arr)
+#    print(R_lw_arr)
+#    print(R_lw_out_arr)
+#    print(E)
+#    print(H)
+#    fluxes = R_sw_arr[:-1]*(1-alpha_sw) + R_lw_arr[:-1]*(1-alpha_lw) - R_lw_out_arr[:-1] + E[:-1]
+    fluxes = (R_sw_arr[:-1]*(1-alpha_sw) + R_lw_arr[:-1]*(1-alpha_lw) - R_lw_out_arr[:-1] + E[:-1] + H[:-1])
+    return fluxes

--- a/tf_tuning/prep_data.py
+++ b/tf_tuning/prep_data.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec 12 16:17:36 2018
+
+@author: aappling
+"""
+
+import numpy as np
+
+def prep_data(
+        N_sec, n_steps, batch_size, input_size, phy_size,
+        x_full_file = 'processed_features.npy',
+        x_raw_full_file = 'features.npy',
+        diag_full_file = 'diag.npy',
+        depth_areas_file = 'depth_areas.npy',
+        label_file = 'Obs_temp_mille.npy',
+        mask_file = 'Obs_mask_mille.npy',
+        train_range = range(10000, 12500),
+        test_range = range(10000),
+        data_path='data'):
+    """Read and format data
+    
+    Args:
+        N_sec: Number of sections to arrange vertically within the input for a batch (after splitting into windows of width n_steps)
+        n_steps: Number of timesteps in the time window represented by the LSTM (shorter than total number of timesteps in the dataset or even the batch)
+        batch_size: Number of dates (timesteps) within one batch. We're not breaking epochs into batches, but we do prep data in the shape of batches stacked vertically, such that we could use training batches later if desired. Should divide evenly into training and test range lengths.
+        input_size: Number of features in the input data (drivers) used for supervised learning
+        phy_size: Number of features in the input data (drivers) used for UNsupervised learning. These data should be unnormalized.
+        x_full_file: Filename of normalized inputs (climate, possibly GLM)
+        x_raw_full_file: Filename of raw (unnormalized) inputs
+        diag_full_file: Filename of supplemental inputs for unsupervised training
+        depth_areas_file: Filename of np array of depth areas. The length of this array is used to determine number of depths
+        label_file: Filename of labels (temperature observations for training; GLM predictions for pretraining)
+        mask_file: Filename of label masks (0 where temp obs/GLM pred unavailable, 1 where available)
+        train_range: Date/timestep range or indices to select from the input files for training. Use a smaller range (2500) unless you have large-memory (~32Gb) GPU in which case 7500 is OK.
+        test_range: Date/timestep range or indices to select from the input files for testing. 
+        data_path: Path to the data files. './data' is recommended.    
+    """
+    
+    # Read in the predictor data (scaled and unscaled climate variables, mask, etc.)
+    x_full = np.load('%s/%s' % (data_path, x_full_file))
+    x_raw_full = np.load('%s/%s' % (data_path, x_raw_full_file))
+    diag_full = np.load('%s/%s' % (data_path, diag_full_file))
+    phy_full = np.concatenate((x_raw_full[:,:,:-2],diag_full),axis=2)
+    depth_areas = np.load('%s/%s' % (data_path, depth_areas_file))
+    n_depths = depth_areas.size
+    
+    # Read in the observation data (temperature)
+    label = np.load('%s/%s' % (data_path, label_file)) # Observations
+    if mask_file == '':
+        mask = np.ones([label.shape[0],label.shape[1]])*1.0 # no masking
+    else:
+        mask = np.load('%s/%s' % (data_path, mask_file))
+     
+    # Separate training sets from test sets
+    x_tr = x_full[:,train_range,:] # was 5000:12500. use a smaller dataset for testing on alison's memory-poor GPU
+    y_tr = label[:,train_range]
+    p_tr = phy_full[:,train_range,:]
+    m_tr = mask[:,train_range]
+    
+    x_te = x_full[:,test_range,:]
+    y_te = label[:,test_range]
+    p_te = phy_full[:,test_range,:]
+    m_te = mask[:,test_range]
+    
+    num_train_batches = np.int(np.ceil(train_range.__len__()/batch_size)) # __len__() requires python 3
+    x_train_1 = np.zeros([n_depths*N_sec*num_train_batches, n_steps, input_size])
+    y_train_1 = np.zeros([n_depths*N_sec*num_train_batches, n_steps])
+    p_train_1 = np.zeros([n_depths*N_sec*num_train_batches, n_steps, phy_size])
+    m_train_1 = np.zeros([n_depths*N_sec*num_train_batches, n_steps])
+    
+    num_test_batches = np.int(np.ceil(test_range.__len__()/batch_size)) # __len__() requires python 3
+    x_test = np.zeros([n_depths*N_sec*num_test_batches, n_steps, input_size])
+    y_test = np.zeros([n_depths*N_sec*num_test_batches, n_steps])
+    p_test = np.zeros([n_depths*N_sec*num_test_batches, n_steps, phy_size])
+    m_test = np.zeros([n_depths*N_sec*num_test_batches, n_steps])
+    
+    # rearrange data by batches and segments=windows within each batch,
+    # going from a horizontal arrangement (depths x dates [x num features])
+    # to a more vertical arrangement (depths*n_windows_per_batch*n_batches x n_dates_per_window [x num features]).
+    # NOTE that we don't actually use batches in the NN training, but this arrangement
+    # makes it so we could (because windows don't cross over between batches, even though
+    # they can overlap within a batch)
+    for i in range(1,N_sec+1): # iterate over the windows (sections)
+        
+        for j in range(num_train_batches):
+            # pick out one training batch (subset by dates)
+            tr_1_range = range((j)*batch_size, (j+1)*batch_size)
+            x_tr_1 = x_tr[:,tr_1_range,:]
+            y_tr_1 = y_tr[:,tr_1_range]
+            p_tr_1 = p_tr[:,tr_1_range,:]
+            m_tr_1 = m_tr[:,tr_1_range]
+            
+            # move the ith window from that training batch into its own vertical segment
+            horiz_window_inds = range(int((i-1)*n_steps/2), int((i+1)*n_steps/2)) # window centered on i*n_steps
+            vert_batch_start = j*n_depths*N_sec # move that window down to the next open vertical chunk
+            vert_window_inds = range((i-1)*n_depths + vert_batch_start, i*n_depths + vert_batch_start)
+            x_train_1[vert_window_inds,:,:] = x_tr_1[:,horiz_window_inds,:]
+            y_train_1[vert_window_inds,:] = y_tr_1[:,horiz_window_inds]
+            p_train_1[vert_window_inds,:,:] = p_tr_1[:,horiz_window_inds,:]
+            m_train_1[vert_window_inds,:] = m_tr_1[:,horiz_window_inds]
+        
+        for j in range(num_test_batches):
+            te_1_range = range((j)*batch_size, (j+1)*batch_size)
+            x_te_1 = x_te[:,te_1_range,:]
+            y_te_1 = y_te[:,te_1_range]
+            p_te_1 = p_te[:,te_1_range,:]
+            m_te_1 = m_te[:,te_1_range]
+            
+            horiz_window_inds = range(int((i-1)*n_steps/2), int((i+1)*n_steps/2))
+            vert_batch_start = j*n_depths*N_sec
+            vert_window_inds = range((i-1)*n_depths+vert_batch_start, i*n_depths+vert_batch_start)
+            x_test[vert_window_inds,:,:] = x_te_1[:,horiz_window_inds,:]
+            y_test[vert_window_inds,:] = y_te_1[:,horiz_window_inds]
+            p_test[vert_window_inds,:,:] = p_te_1[:,horiz_window_inds,:]
+            m_test[vert_window_inds,:] = m_te_1[:,horiz_window_inds]
+    
+    
+    # prepare the unsupervised learning data, for which we can pass in predictors adn 
+    x_f = np.concatenate((x_test,x_train_1),axis=0)
+    p_f = np.concatenate((p_test,p_train_1),axis=0)
+    
+    return(x_train_1, y_train_1, m_train_1, x_f, p_f, x_test, y_test, m_test, depth_areas)

--- a/tf_tuning/run_job.py
+++ b/tf_tuning/run_job.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Usage: python run_job.py <job>
+# where <job> is job number from 0 to (number of elements in model_params.py - 1)
+
+import sys
+import numpy as np
+import apply_pgnn
+
+# read the job number from the command-line arguments
+job = int(sys.argv[1])
+print(job)
+
+# read and format the parameters corresponding to that job number
+model_params = np.load('model_params.npy').item()
+params_key = list(model_params.keys())[job]
+params = model_params[params_key]
+pretrain = (params_key.split('_')[0] == 'pretrain') # assumes params_key like "pretrain_1a" or "train_2c"
+restore_path = '' if pretrain else ('./mille/out/pre%s' % params_key)
+print(params_key)
+print(pretrain)
+print(restore_path)
+
+# use the parameters to pretrain or train a model
+apply_pgnn.apply_pgnn(
+    input_size = 9,
+    phy_size = 10,
+    n_steps = 50,
+    batch_size = 500,
+    learning_rate = 0.008 if pretrain else 0.005,
+    state_size = params['state_size'], # Step 1: try number of input drivers, and half and twice that number
+    ec_threshold = 24, # TODO: calculate for each lake: take GLM temperatures, calculate error between lake energy and the fluxes, take the maximum as the threshold. Can tune from there, but it usually doesn’t change much from the maximum 
+    plam = 1.0, # TODO: implement depth-density constraint in model
+    elam = 0.001, # original mille lacs values were 0.0005, 0.00025
+    # TODO: should have L1 and L2 norm weights in this list, implemented in tf_graph
+    
+    x_full_file = 'processed_features.npy',
+    x_raw_full_file = 'features.npy',
+    diag_full_file = 'diag.npy',
+    depth_areas_file = 'depth_areas.npy',
+    label_file = 'labels.npy' if pretrain else 'Obs_temp_mille.npy', # labels.npy is GLM outputs, Obs is real temp data
+    mask_file = '' if pretrain else 'Obs_mask_mille.npy', # mask can be all 1's ('') for GLM, which has no missing values
+    train_range = range(5000, 6500) if pretrain else range(10000, 12500), # for Mille Lacs we're using the later part of the data for training, previous years for testing
+    test_range = range(0, 5000) if pretrain else range(5000, 10000), # not really sure why train and test are different for pretrain and train
+    data_path = './mille/data',
+    
+    tot_epochs = 300,
+    min_epochs_test = 150 if pretrain else 100,
+    min_epochs_save = 250,
+    restore_path = '' if pretrain else ('./mille/out/pre%s' % params_key),
+    save_path = './mille/out/%s' % params_key,
+    max_to_keep = 5 if pretrain else 3,
+    save_preds = False if pretrain else True
+)

--- a/tf_tuning/slurm_jobs.sh
+++ b/tf_tuning/slurm_jobs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH --job-name=tune_pgnn   # name that you chose
+#SBATCH -A watertemp           # your account
+#SBATCH -p UV                  # the partition you want to use - for GPUs, use UV
+#SBATCH -c 1                   # number of cores per task
+#SBATCH --gres=gpu:tesla:1     # specify how many GPU cores you want, and what kind (tesla or quadro)
+#SBATCH --time=00:10:00        # time at which the process will be cancelled if unfinished
+#SBATCH -o log/tune-tesla/%A_%a.log  # sets output log file to array_job.log
+#SBATCH -e log/tune-tesla/%A_%a.err  # sets error log file to array_job.err
+#SBATCH --export=ALL
+#SBATCH --array=0-2            # process IDs corresponding to list order (0-indexed) of model_params.npy
+
+cd /cxfs/projects/usgs/water/iidd/data-sci/lake-temp/nn-test
+module load python/anaconda3 cuda/9.0.176
+source activate tensorflow
+python run_job.py ${SLURM_ARRAY_TASK_ID}
+source deactivate
+
+# Usage:
+# sbatch -a 0-1 slurm_jobs.sh
+# sbatch slurm_jobs.sh

--- a/tf_tuning/tf_graph.py
+++ b/tf_tuning/tf_graph.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Dec  7 18:05:09 2018
+
+@author: aappling
+"""
+
+import tensorflow as tf
+import physics as phy
+
+def build_tf_graph(n_steps, input_size, state_size, phy_size, depth_areas, ec_threshold, plam, elam, N_sec, learning_rate):
+    """Builds a tensorflow graph for the PRGNN model
+    
+    Args:
+        n_steps: Number of timesteps in the time window represented by the LSTM (shorter than total number of timesteps in the dataset or even the batch)
+        input_size: Number of features in the input data (drivers) used for supervised learning
+        state_size: Number of units in each LSTM cell's hidden state
+        phy_size: Number of features in the input data (drivers) used for UNsupervised learning. These data should be unnormalized.
+        ec_threshold: Tolerance for energy imbalance before any penalization occurs
+        plam: Physics constraint lambda, a hyperparameter that needs manual tuning. PRESENTLY IGNORED (no physics constraint)
+        elam: Energy constraint lambda, another hyperparameter that needs manual tuning. Could set elam=0 if we wanted RNN only, no EC component
+        N_sec: Number of sections to arrange vertically within the input for a batch (after splitting into windows of width n_steps)
+        learning_rate: Learning rate
+    """
+    
+    # Clear the slate
+    tf.reset_default_graph()
+
+    # Graph input/output. n timesteps is less than the total number of timesteps at the lake; it's just hte window width
+    x = tf.placeholder("float", [None, n_steps, input_size]) #[n depths, n_timesteps, n drivers]
+    y = tf.placeholder("float", [None, n_steps]) # [n depths, n timesteps]
+    m = tf.placeholder("float", [None, n_steps])
+    
+    # Define LSTM cells
+    lstm_cell = tf.contrib.rnn.BasicLSTMCell(state_size, forget_bias=1.0) # define a single LSTM cell
+    # dynamic_rnn is faster for long timeseries, compared to tf.nn.static_rnn. the default namespace for tf.nn.dynamic_rnn in "rnn"; this becomes importatin in line 367
+    state_series_x, current_state_x = tf.nn.dynamic_rnn(lstm_cell, x, dtype=tf.float32) # add multiple LSTM cells to the network. uses the dimensions of x to choose the dimensions of the LSTM network
+    
+    # Output layer
+    n_classes = 1 # Number of output values (probably 1 for a single depth-specific, time-specific prediction)
+    w_fin = tf.get_variable('w_fin',[state_size, n_classes], tf.float32,
+                                     tf.random_normal_initializer(stddev=0.02))
+    b_fin = tf.get_variable('b_fin',[n_classes],  tf.float32,
+                                     initializer=tf.constant_initializer(0.0))
+    
+    # Define how LSTM and final layers are connected to make predictions
+    pred=[]
+    for i in range(n_steps):
+        tp1 = state_series_x[:,i,:] #state_series_x dimensions are [n depths, n timesteps, n hidden units]
+        pt = tf.matmul(tp1,w_fin)+b_fin
+        pred.append(pt) # couldn't do pred[i] = pt because tensorflow wouldn't like it
+    
+    pred = tf.stack(pred,axis=1) # converts the preds list to a tensorflow array. [n depths, n timesteps, 1] (the last dimension isn'd really needed; we'll remove it later)
+    pred_s = tf.reshape(pred,[-1,1]) # collapse from 3D [depths, timesteps, 1] to 2D [depths * timesteps, 1]
+    y_s = tf.reshape(y,[-1,1])
+    m_s = tf.reshape(m,[-1,1]) # this is the mask of 0s and 1s (1 means the observation exists)
+        
+    # Compute cost with masking (m_s)
+    r_cost = tf.sqrt(tf.reduce_sum(tf.square(tf.multiply((pred_s-y_s),m_s)))/tf.reduce_sum(m_s)) # note use of masks m_s
+    # the only other cost function we might reasonably consider, besides RMSE above, might be MAE...but they're quite similar
+    
+    ### EC penalization (using unsupervised learning, which allows us to use a larger dataset than the above supervised learning can
+    
+    #unsup = unsupervised. this is a placeholder for all the drivers relevant to the EC computation
+    # this is a second phase of training, called semi-supervised learning, where we only apply one part of the loss function (the EC part).
+    # so we still learn something, if not as much as we learned from the days with observations
+    unsup_inputs = tf.placeholder("float", [None, n_steps, input_size]) #tf.float32 [the 30 years of data, n timesteps per window, n drivers]
+    # the variable_scope part needs to match the variable_scope we used before, rnn, so that tf.nn.dynamic_rnn(lstm_cell) uses and
+    # trains the same lstm parameters as before
+    with tf.variable_scope("rnn", reuse=True) as scope_sp:
+        state_series_xu, current_state_xu = tf.nn.dynamic_rnn(lstm_cell, unsup_inputs, dtype=tf.float32, scope=scope_sp) 
+    
+    pred_u=[] # same as above for the supervised part
+    #pred_s = []
+    for i in range(n_steps):
+        tp2 = state_series_xu[:,i,:] # state_series_xu is hte state series from teh unsupervised input
+        pt2 = tf.matmul(tp2,w_fin)+b_fin
+        pred_u.append(pt2)
+    
+    pred_u = tf.stack(pred_u,axis=1)
+    pred_u = tf.reshape(pred_u,[-1,n_steps])
+    
+    # unsupervised physics data include the non-normalized versions of the drivers (for the LSTM we wanted the normalized, mean=0, sd=1 version)
+    unsup_phys_data = tf.placeholder("float", [None, n_steps, phy_size]) #tf.float32
+    n_depths = depth_areas.size
+
+    unsup_loss,a,b,c = phy.calculate_ec_loss(
+        unsup_inputs,
+        pred_u,
+        unsup_phys_data,                                     
+        depth_areas,
+        n_depths,
+        ec_threshold,
+        N_sec,
+        combine_days=1)
+    
+    # Compute total costs
+    cost = r_cost + elam*unsup_loss#+plam*plos+plam*plos_u. 
+        
+    # Define the gradients and optimizer
+    tvars = tf.trainable_variables()
+    grads = tf.gradients(cost, tvars)
+    optimizer = tf.train.AdamOptimizer(learning_rate)
+    train_op = optimizer.apply_gradients(zip(grads, tvars))
+    
+    return(train_op, cost, r_cost, pred, unsup_loss, x, y, m, unsup_inputs, unsup_phys_data)

--- a/tf_tuning/tf_train.py
+++ b/tf_tuning/tf_train.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec 12 12:16:35 2018
+
+@author: aappling
+"""
+
+import numpy as np
+import tensorflow as tf
+
+def train_tf_graph(
+        train_op, cost, r_cost, pred, unsup_loss, x, y, m, unsup_inputs, unsup_phys_data,
+        x_train_1, y_train_1, m_train_1, x_f, p_f, x_test, y_test, m_test,
+        tot_epochs=300, min_epochs_test=0, min_epochs_save=250,
+        restore_path='', save_path='./out/EC_mille/pretrain', max_to_keep=3, save_preds=True):
+    """Trains a tensorflow graph for the PRGNN model
+    
+    Args:
+        train_op, cost, r_cost, pred, unsup_loss, x, y, m, unsup_inputs, unsup_phys_data: tf tensors
+        x: Input data for supervised learning
+        y: Observations for supervised learning
+        m: Observation mask for supervised learning
+        x_f: Input data for unsupervised learning
+        p_f: Observations for unsupervised learning (p = physics)
+        x_test: Inputs data for testing
+        y_test: Observations for testing
+        m_test: Observation mask for testing
+        tot_epochs: Total number of epochs to run during training. Needs to be larger than the n epochs needed for the model to converge
+        min_epochs_test: Minimum number of epochs to run through before computing test losses
+        min_epochs_save: Minimum number of epochs to run through before considering saving a checkpoint (must be >= min_epochs_test)
+        restore_path: Path to restore a model from, or ''
+        save_path: Path (directory) to save a model to. Will always be saved as ('checkpoint_%s' %>% epoch)
+        max_to_keep: Max number of checkpoints to keep in the save_path
+        save_preds: Logical - should test predictions be saved (and ovewritten) each time we save a checkpoint?
+    """
+    
+    # Prepare a NN saver
+    saver = tf.train.Saver(max_to_keep=max_to_keep) # tells tf to prepare to save the graph we've defined so far
+
+    # Initialize merr to a flag value so we know to replace it with the first computed test loss
+    merr = -1 
+    
+    with tf.Session() as sess:
+
+        # If using pretrained model, reload it now   
+        if restore_path != '':
+            latest_ckp = tf.train.latest_checkpoint(restore_path)
+            #from tensorflow.python.tools.inspect_checkpoint import print_tensors_in_checkpoint_file
+            #print_tensors_in_checkpoint_file(latest_ckp, all_tensors=True, tensor_name='')
+            saver.restore(sess, latest_ckp)
+            
+        # Initialize the weights and biases
+        sess.run(tf.global_variables_initializer())
+    
+        for epoch in range(tot_epochs):
+            # Train on training set, including both supervised and unsupervised data
+            _, loss, rc, ec = sess.run( # this is where you feed in data and get output from the graph
+                    [train_op, cost, r_cost, unsup_loss], # tells sess.run which tensorflow variables to update during each epoch. train_op is important because that contains the gradients for all the costs and variables. all others are optional to track here. a, b, and c are debugging variables xiaowei wanted
+                    feed_dict = { # inputs to the function
+                            x: x_train_1, # now these have a realized first dimension, the num depths * num windows, which is 24*300 for Mille Lacs
+                            y: y_train_1,
+                            m: m_train_1,
+                            unsup_inputs: x_f,
+                            unsup_phys_data: p_f
+            })
+            
+            # Report training losses
+            print(
+                "Step " + str(epoch) \
+                + ", loss_train " + "{:.4f}".format(loss) \
+                + ", Rc " + "{:.4f}".format(rc) \
+                + ", Ec " + "{:.4f}".format(ec))
+    
+            if epoch >= min_epochs_test - 1:
+                # Calculate loss and temperature predictions (prd) for test set
+                loss_test, prd = sess.run(
+                        [r_cost, pred], # note that this first arg doesn't include train_op, so we're not updating the model now that we're applying to the test set
+                        feed_dict = {
+                                x: x_test,
+                                y: y_test,
+                                m: m_test
+                })
+    
+                # Initialize merr if needed
+                if merr == -1:
+                    merr = loss_test
+                
+                # Save the predictions and/or model state if this is the minimum loss we've seen
+                if merr > loss_test:
+                    merr = loss_test
+                    if epoch >= min_epochs_save - 1: # (and only do this saving if we're already past some # of epochs)
+                        save_file = saver.save(sess, "%s/checkpoint_%03d" % (save_path, epoch))
+                        print("  Model saved to %s" % save_file)
+                        if save_preds:
+                            np.save('%s/preds.npy' % save_path, prd)
+    
+                # Report test losses
+                print(
+                    "  loss_test " + "{:.4f}".format(loss_test) \
+                    + ", min_loss " + "{:.4f}".format(merr) )
+    
+    return prd


### PR DESCRIPTION
This code is a modified version of the scripts Xiaowei shared two weeks ago at our UMN meeting. I've abstracted the pieces into modules for physics, building the network, preparing the network, training the network and making predictions, building+running a network from start to finish, and building_running a network with a specific set of model parameters. Then this PR also allows the slurm script to iterate over multiple parameter sets to support the parameter tuning algorithm we've outlined at https://docs.google.com/document/d/1RG5fCxlk9e93BM8iSKQQIXk5q8889FicvxSuZr2Zp8A/edit#heading=h.i70p3vnozl5v.

See the READMEs for directions on how to get going. I've run this successfully locally and on quadro GPU cores on Yeti. I'm waiting for a turn to test on some tesla cores now and expect success.

See https://docs.google.com/document/d/1ZpHtw4Q3Is23YAmp6qb1vcCc2u4dc7NKMARBf7Harmw/edit# for general directions on how to get going on Yeti (now a bit out of date with respect to the slurm script in this PR). I'm not sure whether the conda environment is accessible just to me or to all of us...but I believe this doc has the right instructions for how to create that environment for yourself. Remember to load the anaconda3 and cuda/9 modules first, then creating the environment involves installing python packages that will support tensorflow on GPUs.